### PR TITLE
Support "wb" mode for opening files

### DIFF
--- a/src/FSWrapper.cpp
+++ b/src/FSWrapper.cpp
@@ -229,7 +229,7 @@ FSError FSWrapper::FSOpenFileWrapper(const char *path, const char *mode, FSFileH
         _mode = O_RDONLY;
     } else if (strcmp(mode, "r+") == 0) {
         _mode = O_RDWR;
-    } else if (strcmp(mode, "w") == 0) {
+    } else if (strcmp(mode, "w") == 0 || strcmp(mode, "wb") == 0) {
         _mode = O_WRONLY | O_CREAT | O_TRUNC;
     } else if (strcmp(mode, "w+") == 0) {
         _mode = O_RDWR | O_CREAT | O_TRUNC;
@@ -659,6 +659,7 @@ bool FSWrapper::IsFileModeAllowed(const char *mode) {
 
     if (pIsWriteable && (strcmp(mode, "r+") == 0 ||
                          strcmp(mode, "w") == 0 ||
+                         strcmp(mode, "wb") == 0 ||
                          strcmp(mode, "w+") == 0 ||
                          strcmp(mode, "a") == 0 ||
                          strcmp(mode, "a+") == 0)) {


### PR DESCRIPTION
by @neoninteger:
```
Hachihachi (the Nintendo DS emulator used in Virtual Console) crashes when its save data is redirected to the SD card. It tries to open the save-state files in "wb" mode which is currently rejected by the ContentRedirectionModule. This causes the emulator's `SAVEOpenFile()` call to fail, and the emulator immediately panics.

I am operating under the assumption that the Wii U's I/O system doesn't differentiate between text and binary modes, like most other operating systems. This is evidenced by the fact that the module already supports "rb" mode and treats it in the same way as "r".
```